### PR TITLE
feat: templateUrl should support double quotes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ function inlineResourcesFromString(content: string, urlResolver: UrlResolver) {
  * @return {string} The content with all templates inlined.
  */
 function inlineTemplate(content: string, urlResolver: UrlResolver) {
-  return content.replace(/templateUrl:\s*'([^']+?\.html)'/g, function (_m, templateUrl) {
+  return content.replace(/templateUrl:\s*['"]([^'"]+?\.html)['"]/g, function (_m, templateUrl) {
     const templateFile = urlResolver(templateUrl);
     const templateContent = fs.readFileSync(templateFile, 'utf-8');
     const shortenedTemplate = templateContent

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -1,2 +1,3 @@
 export { libComponent } from './lib.component';
 export { libNotComponent } from './lib.not-component';
+export { libDoubleQuotesComponent } from './lib.double-quotes.component';

--- a/test/src/lib.double-quotes-component.html
+++ b/test/src/lib.double-quotes-component.html
@@ -1,0 +1,1 @@
+<p>lib-component-double-quotes-html</p>

--- a/test/src/lib.double-quotes.component.js
+++ b/test/src/lib.double-quotes.component.js
@@ -1,0 +1,4 @@
+export var libDoubleQuotesComponent = {
+  templateUrl: "lib.double-quotes-component.html",
+  styleUrls: ["lib.component.css", "another-lib.component.css"]
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -25,5 +25,5 @@ describe('Angular Inline', () => {
   it('should replace templateUrl when using doublequotes', () => {
     assert(lib.match('lib-component-double-quotes-html'));
   });
-  
+
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -22,4 +22,8 @@ describe('Angular Inline', () => {
     assert(lib.match('another-lib.not-component.css'));
   });
 
+  it('should replace templateUrl when using doublequotes', () => {
+    assert(lib.match('lib-component-double-quotes-html'));
+  });
+  
 });


### PR DESCRIPTION
Components with double quotes value for templateUrl were not detected for inline replacement.